### PR TITLE
Parameter for reverse scaffold visualization added

### DIFF
--- a/MACE/Routines/Visualization.py
+++ b/MACE/Routines/Visualization.py
@@ -130,6 +130,7 @@ class Visualization(DrawingRoutines):
                                       title=None,
                                       extensions=("png", ),
                                       scaffold_order_list=None,
+                                      scaffold_reverse_list=None,
                                       test_colormaps=False,
                                       masking=True,
                                       multiplier=1000,
@@ -150,6 +151,7 @@ class Visualization(DrawingRoutines):
                           title=title,
                           extensions=extensions,
                           scaffold_order_list=scaffold_order_list,
+                          scaffold_reverse_list=scaffold_reverse_list,
                           test_colormaps=test_colormaps,
                           masking=masking,
                           multiplier=multiplier,
@@ -241,6 +243,7 @@ class Visualization(DrawingRoutines):
                      title=None,
                      extensions=("png", ),
                      scaffold_order_list=None,
+                     scaffold_reverse_list=None,
                      test_colormaps=False,
                      masking=True,
                      multiplier=None,
@@ -284,7 +287,11 @@ class Visualization(DrawingRoutines):
             track_group_style = TrackGroupStyle(label_fontstyle=track_group_label_fontstyle)
 
             for chr in scaffolds: # count_df.index.get_level_values(level=0).unique():
-                track_group_dict[chr] = TrackGroup(label=chr if show_trackgroup_label else None,
+                if show_trackgroup_label:
+                    label = "* " + chr if chr in scaffold_reverse_list else chr # setting reverse scaffold label
+                else:
+                    label = None
+                track_group_dict[chr] = TrackGroup(label=label,
                                                    style=track_group_style)
                 tracks_to_use = list(count_df.columns)
                 if "masked" in tracks_to_use:
@@ -303,7 +310,8 @@ class Visualization(DrawingRoutines):
                                                                     colormap=colormap_entry,
                                                                     thresholds=thresholds,
                                                                     colors=colors, background=background,
-                                                                    masked=masked, norm=norm)
+                                                                    masked=masked, norm=norm,
+                                                                    track_reverse=True if chr in scaffold_reverse_list else False)
                     track_group_dict[chr][track_name].add_color(masking=masking)
                     track_number += 1
             chromosome_subplot = Subplot(track_group_dict,

--- a/MACE/Visualization/Tracks.py
+++ b/MACE/Visualization/Tracks.py
@@ -162,7 +162,7 @@ class WindowTrack(Track):
                  style=default_track_style, label=None, norm=False,
                  window_type="stacking", multiplier=None, feature_style=default_feature_style, color_expression=None,
                  colormap=None, thresholds=None,
-                 colors=None, background=None, masked=None, subplot_scale=False,
+                 colors=None, background=None, masked=None, subplot_scale=False, track_reverse=False,
                  track_group_scale=False, figure_x_y_ration=None, subplot_x_y_ratio=None, track_group_x_y_ratio=None):
         """
 
@@ -220,13 +220,32 @@ class WindowTrack(Track):
         self.window_size = window_size
         self.window_step = window_step
         self.multiplier = multiplier
-        self.preprocess_data()
+        if track_reverse:
+            self.preprocess_data_track_reverse()
+        else:
+            self.preprocess_data()
 
     def preprocess_data(self):
         window_index_name = self.records.index.names[0]
         if self.window_type == "stacking":
             self.records.reset_index(level=window_index_name, inplace=True)
             self.records["start"] = self.records[window_index_name] * self.window_step
+            self.records = self.records[["start"] + list(self.records.columns[:-1])]
+
+        elif self.window_type == "sliding":
+            # TODO: implement sliding window
+            # TODO: verify - sliding window drawing is already implemented  somewhere else:)))
+            pass
+        else:
+            raise ValueError("ERROR!!! Unknown window type: %s" % self.window_type)
+
+    def preprocess_data_track_reverse(self):
+        window_index_name = self.records.index.names[0]
+        indent_len = self.x_end - self.records.index[-1] * self.window_size - self.window_size
+        if self.window_type == "stacking":
+            self.records.reset_index(level=window_index_name, inplace=True)
+            self.records["density"] = self.records["density"].values[::-1]
+            self.records["start"] =  self.records[window_index_name] * self.window_step + indent_len
             self.records = self.records[["start"] + list(self.records.columns[:-1])]
 
         elif self.window_type == "sliding":

--- a/scripts/draw_variant_window_densities.py
+++ b/scripts/draw_variant_window_densities.py
@@ -81,7 +81,9 @@ parser.add_argument("--syn_file_key_column", action="store", dest="syn_file_key_
 parser.add_argument("--syn_file_value_column", action="store", dest="syn_file_value_column",
                     default=1, type=int,
                     help="Column(0-based) with value(synonym id) for scaffolds in synonym file synonym. Default: 1")
-
+parser.add_argument("--scaffold_reverse_list", action="store", dest="scaffold_reverse_list", default=[],
+                    type=lambda s: IdList(filename=s) if os.path.exists(s) else s.split(","),
+                    help="Comma-separated list of the only scaffolds to reverse draw. Default: not set")
 """
 parser.add_argument("-q", "--figure_width", action="store", dest="figure_width", default=12, type=int,
                     help="Width of figure in inches. Default: 12")
@@ -187,6 +189,7 @@ if not args.only_count:
                                                 colormap=args.colormap, title=args.title,
                                                 extensions=args.output_formats,
                                                 scaffold_order_list=args.scaffold_ordered_list,
+                                                scaffold_reverse_list=args.scaffold_reverse_list,
                                                 test_colormaps=args.test_colormaps,
                                                 thresholds=args.density_thresholds,
                                                 masking=True if args.coverage else False,


### PR DESCRIPTION
Unfortunately, if you parse a VCF file in reverse order, the track start coordinate does not change. It can only be changed in MACE/Visualization/Tracks.py. That's why I've decided not to go beyond the WindowTrack class. This way seemed the most logical to me. As you asked, I did not change the function preprocess_data(), but added an anologue preprocess_data_track_reverse().
In addition, the reverse scaffolds are marked with "*" at the beginning of the track name (e.g., "* chrX" instead of "chrX"). I think this isn't a bad way to distinguish between reverse scaffolds.