### PR TITLE
scripts parser fix

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,14 +1,8 @@
 __author__ = 'mahajrod'
 
-import os
-
-from setuptools import setup, find_packages
-
+from pathlib import Path
 from os.path import join, dirname
-
-scripts = os.listdir("scripts/")
-
-scripts = ["scripts/%s" % script for script in scripts]
+from setuptools import setup, find_packages
 
 
 setup(name='MACE',
@@ -18,4 +12,4 @@ setup(name='MACE',
       author_email='mahajrod@gmail.com',
       install_requires=['scipy', 'numpy', 'matplotlib', 'biopython', 'bcbio-gff'],
       long_description=open(join(dirname(__file__), 'README.md')).read(),
-      scripts=scripts)
+      scripts=list(map(str, sorted(Path('scripts/').glob("*.py")))))


### PR DESCRIPTION
Files "scripts/*py" are parsed using pathlib. Scripts in directory "scripts/old/*" is ignored.